### PR TITLE
Implement a Bind Mount for the Docker Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ catkin_make
 Make sure you have the following installed:
 1. [Git](https://gitforwindows.org/)
 2. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-3. [Xming](https://sourceforge.net/projects/xming/)(windows) or [XQuartz](https://www.xquartz.org/)(macOS, not tested)
+3. [Xming](https://sourceforge.net/projects/xming/) (windows) or [XQuartz](https://www.xquartz.org/) (macOS, not tested)
 
 #### Step 1: Clone repo
 Use git bash to clone the repo (to your local machine)
@@ -63,9 +63,11 @@ export DISPLAY=<your ip address (ipv4 ethernet)>:0.0
 Start up Xming and accept all the default configurations and save your configuration to the Xming folder. Make sure the display variable is 0
 
 ### Step 4: Run the container 
-```
-./rsx_docker_run.sh
-```
+
+Use the rsx_docker_run.sh script to create a running container from the docker image (built in step 2). 
+
+> Refer to the [instructions for using rsx_docker_run.sh](docker/running_image_directions.md)
+
 This will interactively run the docker container. You can either use VScode's remote - container extension to connect or continue in the terminal 
 
 ### Step 5: Test

--- a/README.md
+++ b/README.md
@@ -50,16 +50,8 @@ You should get a docker image called rsx_dev_rsx
 
 Note: this will take about 15 minutes as it needs to install ROS onto the nvidia image 
 
-### Step 3: Set up your display variables and start X server
-Start a bash terminal or powershell 
-```
-ipconfig
-```
-Find the ip address of your host. 
-On your host machine:
-```
-export DISPLAY=<your ip address (ipv4 ethernet)>:0.0
-```
+### Step 3: Start X server
+
 Start up Xming and accept all the default configurations and save your configuration to the Xming folder. Make sure the display variable is 0
 
 ### Step 4: Run the container 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,7 +115,7 @@ RUN adduser $username0 root
 RUN adduser $username0 sudo
 RUN echo $username0':rsx123' | chpasswd
 USER $username0
-RUN mkdir -p /home/$username0/rover-ws/src/rsx-rover
+RUN mkdir -p /home/$username0/rover_ws/src/rsx-rover
 
 RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
 RUN echo "export USER=$username0" >> ~/.bashrc

--- a/docker/rsx_docker_run.sh
+++ b/docker/rsx_docker_run.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# takes 2 positional arguments; first is your ipv4 address (for display), second is path to repo (for bind mount)
-# remember to enclose filepath in quotes
-
 ########
 # Init #
 ########
@@ -18,7 +15,7 @@ echo ""
 # Docker run arguments
 docker_args="-it --rm"
 
-display="$1:0.0" # Xming display
+display="$1:0.0" # X display
 repo_path="$2"   # bind mount (see difference between bind mounts and docker volumes: https://www.dltlabs.com/blog/bind-mounts-volumes-indocker-133067)
 
 other_args="

--- a/docker/rsx_docker_run.sh
+++ b/docker/rsx_docker_run.sh
@@ -19,7 +19,7 @@ echo ""
 docker_args="-it --rm"
 
 display="$1:0.0" # Xming display
-repo_path="$2"   # bind mount
+repo_path="$2"   # bind mount (see difference between bind mounts and docker volumes: https://www.dltlabs.com/blog/bind-mounts-volumes-indocker-133067)
 
 other_args="
     --privileged \

--- a/docker/rsx_docker_run.sh
+++ b/docker/rsx_docker_run.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
+# takes 2 positional arguments; first is your ipv4 address (for display), second is path to repo (for bind mount)
+# remember to enclose filepath in quotes
+
 ########
 # Init #
 ########
 
 echo ""
-echo "Running rsx dev docker"
+echo "Starting up container from rsx_dev_rsx"
 echo ""
-
-command=""
-
 
 ##########################
 # Start docker container #
@@ -17,21 +17,18 @@ command=""
 
 # Docker run arguments
 docker_args="-it --rm"
-username="cathe"
 
-# Volumes (modify with your own path here)
-volumes="-v /c/Users/$username/rsx-rover:/home/rsx/rover_ws/src/rsx-rover:rw"
-
-echo $PWD
+display="$1:0.0" # Xming display
+repo_path="$2"   # bind mount
 
 other_args="
     --privileged \
     --net=host \
-    -e DISPLAY=$DISPLAY "
+    -e DISPLAY=$display
+    -v $repo_path:/home/rsx/rover_ws/src/rsx-rover:rw"
 
-winpty docker run $docker_args \
-$other_args \
--e DISPLAY=$DISPLAY \
---name "rsx-dev" \
-rsx_dev_rsx \
-$command
+winpty docker run \
+    $docker_args \
+    $other_args \
+    --name "rsx-dev" \
+    rsx_dev_rsx

--- a/docker/running_image_directions.md
+++ b/docker/running_image_directions.md
@@ -6,6 +6,8 @@ The script takes **two positional arguments:**
 1. your ipv4 address (used for connecting to X server for display)
 2. path to the cloned rsx-rover repo on your local computer (used to establish a bind mount)
 
+You can find your ipv4 address by typing `ipconfig` into a terminal (e.g., bash, powershell, windows cmdline).
+
 For example, if my ipv4 address was 10.0.0.1, and the rsx-rover repo on my computer was at "C:\bryan\rsx-rover", then the command I would run is:
 > `./rsx_docker_run.sh 10.0.0.1 "C:\bryan\rsx-rover"`
 

--- a/docker/running_image_directions.md
+++ b/docker/running_image_directions.md
@@ -1,0 +1,20 @@
+# Using rsx_docker_run.sh
+
+This is a shell script that starts a container from the rsx_dev_rsx image (that you should've created from the Dockerfile using the docker_build.sh script).
+
+The script takes **two positional arguments:**
+1. your ipv4 address (used for connecting to X server for display)
+2. path to the cloned rsx-rover repo on your local computer (used to establish a bind mount)
+
+For example, if my ipv4 address was 10.0.0.1, and the rsx-rover repo on my computer was at "C:\bryan\rsx-rover", then the command I would run is:
+> `./rsx_docker_run.sh 10.0.0.1 "C:\bryan\rsx-rover"`
+
+And in general, the command is:
+
+> `./rsx_docker_run.sh <ipv4-address> <path-to-repo>`
+- remember the quotes around the file path
+- remember the `./` preceding the command
+
+After running the command you'll get a container that you can now work with. You can also then connect to it using VScode.
+
+**The Bind Mount:** the repo on your local computer will be mounted to the `/home/rsx/rover_ws/src/rsx-rover` directory in the container. This means any changes you make to that directory in the container will also change the directory on your local computer and vice versa; they are effectively the same directory.


### PR DESCRIPTION
I updated rsx_docker_run.sh to have a bind mount capable of linking a directory on a Windows computer to one on the container. 

rsx_docker_run.sh now takes two commandline arguments, one being an ipv4 address used to connect to the X server, the second being the path to the rsx-rover repo on their local filesystem. 

When the container starts running, the repo directory will be accessible from the docker container through the bind mount. (I believe bind mounts were what we were going for, instead of volumes; see bind mounts vs volumes: https://www.dltlabs.com/blog/bind-mounts-volumes-indocker-133067)

I also created some instructions for using the script (in the docker folder), and updated the readme instructions.

It works on my windows computer, but we should probably test it on some other computers, and maybe mac computers too (at least right now I see no reason why it wouldn't work on mac, but who knows)