### PR TITLE
Add ROS-independent Code for Object Detection with the RealSense 

### DIFF
--- a/scripts/utils/sensors/independent_realsense.py
+++ b/scripts/utils/sensors/independent_realsense.py
@@ -1,0 +1,49 @@
+'''
+Object Detection with the Intel RealSense D435i Depth Camera.
+
+Code is ROS independent, ideal for quick testing.
+Applies a basic pretrained YOLOv8 model on the 
+video stream from the RealSense. 
+'''
+
+# RealSense SDK Python Wrapper
+import pyrealsense2 as rs 
+
+import numpy as np
+import keyboard
+
+# YOLOv8 Library
+from ultralytics import YOLO
+
+# Realsense interfacing  
+pipe = rs.pipeline()
+cfg  = rs.config()
+
+# Screen Resolution
+WIDTH = 640
+HEIGHT = 480
+
+# Enable RGB Stream
+cfg.enable_stream(rs.stream.color, WIDTH, HEIGHT, rs.format.bgr8, 30) 
+pipe.start(cfg)
+
+# Import trained model
+model = YOLO('yolov8n.pt')
+
+while True:
+    
+    # Get video stream frame.
+    frame = pipe.wait_for_frames()
+    color_frame = frame.get_color_frame()
+
+    # Convert to frame to np array.
+    color_image = np.asanyarray(color_frame.get_data())
+    
+    # Inference on image.
+    results = model(color_image, show=True, conf=0.4, save=False) 
+
+    # Break.
+    if keyboard.is_pressed('q'):
+        break
+
+pipe.stop()


### PR DESCRIPTION
Script for Object Detection with the Intel RealSense D435i Depth Camera. This code applies a basic, pre-trained YOLOv8 model to the D435i's video output, but could easily be adapted for a custom model (replace `yolov8n.pt`). The code is ROS-independent (uses `pyrealsense2` wrapper to interface with the D435i), making ideal for quick testing.  While this code is sufficient for now, in the long term, this code is to be implemented using the RealSense ROS wrapper and `cv_bridge`.

More information about our object detection pipeline can be found in the [wiki](https://github.com/rsx-utoronto/rsx-rover/wiki/Software-Resources#object-detection).